### PR TITLE
File drain

### DIFF
--- a/drain.lisp
+++ b/drain.lisp
@@ -74,7 +74,8 @@
 
 (defclass file-drain (drain)
   ((file :initform NIL :initarg :file :reader file)
-   (stream :initform NIL :initarg :stream :accessor stream)))
+   (stream :initform NIL :initarg :stream :accessor stream)
+   (dont-close :initform NIL :initarg :dont-close :accessor dont-close-p)))
 
 (defmethod print-object ((drain file-drain) stream)
   (print-unreadable-object (drain stream :type T :identity T)
@@ -94,11 +95,13 @@
       (finish size))))
 
 (defmethod end :after ((drain file-drain))
-  (when (stream drain)
+  (when (and (stream drain)
+             (not (dont-close-p drain)))
     (close (stream drain))
     (setf (stream drain) NIL)))
 
 (defmethod free :after ((drain file-drain))
-  (when (stream drain)
+  (when (and (stream drain)
+             (not (dont-close-p drain)))
     (close (stream drain) :abort T)
     (setf (stream drain) NIL)))

--- a/drain.lisp
+++ b/drain.lisp
@@ -73,35 +73,8 @@
     (format stream "~a" (device drain))))
 
 (defclass file-drain (drain)
-  ((file :initform NIL :initarg :file :reader file)
-   (stream :initform NIL :initarg :stream :accessor stream)
-   (dont-close :initform NIL :initarg :dont-close :accessor dont-close-p)))
+  ((file :initform NIL :initarg :file :reader file)))
 
 (defmethod print-object ((drain file-drain) stream)
   (print-unreadable-object (drain stream :type T :identity T)
     (format stream "~a" (file drain))))
-
-(defmethod start :before ((drain file-drain))
-  (with-slots (file stream) drain
-    (setf stream
-          (or stream
-              (open file :direction :output
-                         :element-type '(unsigned-byte 8))))))
-
-(defmethod mix ((drain file-drain))
-  (with-buffer-tx (data start size (pack drain))
-    (when (< 0 size)
-      (write-sequence data (stream drain) :start start :end (+ start size))
-      (finish size))))
-
-(defmethod end :after ((drain file-drain))
-  (when (and (stream drain)
-             (not (dont-close-p drain)))
-    (close (stream drain))
-    (setf (stream drain) NIL)))
-
-(defmethod free :after ((drain file-drain))
-  (when (and (stream drain)
-             (not (dont-close-p drain)))
-    (close (stream drain) :abort T)
-    (setf (stream drain) NIL)))

--- a/drain.lisp
+++ b/drain.lisp
@@ -73,7 +73,8 @@
     (format stream "~a" (device drain))))
 
 (defclass file-drain (drain)
-  ((file :initform NIL :initarg :file :reader file)))
+  ((file :initform NIL :initarg :file :reader file)
+   (frame-position :initform 0 :accessor frame-position)))
 
 (defmethod print-object ((drain file-drain) stream)
   (print-unreadable-object (drain stream :type T :identity T)

--- a/examples/cl-mixed-examples.asd
+++ b/examples/cl-mixed-examples.asd
@@ -19,7 +19,9 @@
                (:file "space")
                (:file "echo")
                (:file "play")
+               (:file "play-to-file")
                (:file "mixer"))
   :depends-on (:cl-mixed
                :cl-mixed-out123
-               :cl-mixed-mpg123))
+               :cl-mixed-mpg123
+               :cl-mixed-wav))

--- a/examples/package.lisp
+++ b/examples/package.lisp
@@ -6,7 +6,7 @@
 
 (defpackage #:org.shirakumo.fraf.mixed.examples
   (:use #:cl)
-  (:shadow #:space)
+  (:shadow #:space #:stream)
   (:local-nicknames
    (#:mixed #:org.shirakumo.fraf.mixed)
    (#:out123 #:org.shirakumo.fraf.out123)
@@ -14,6 +14,7 @@
   (:export
    #:mixer
    #:play
+   #:play-to-file
    #:echo
    #:space
    #:tone))

--- a/examples/play-to-file.lisp
+++ b/examples/play-to-file.lisp
@@ -1,0 +1,62 @@
+#|
+ This file is a part of cl-mixed
+ (c) 2017 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
+ Author: Gleefre
+|#
+
+(in-package #:org.shirakumo.fraf.mixed.examples)
+
+(defclass raw-file-drain (mixed:file-drain)
+  ((stream :initform NIL :initarg :stream :accessor stream)
+   (dont-close :initform NIL :initarg :dont-close :accessor dont-close-p)))
+
+(defmethod mixed:start :before ((drain raw-file-drain))
+  (with-slots (mixed:file stream) drain
+    (setf stream
+          (or stream
+              (open mixed:file :direction :output
+                               :element-type '(unsigned-byte 8))))))
+
+(defmethod mixed:mix ((drain raw-file-drain))
+  (mixed:with-buffer-tx (data start size (mixed:pack drain))
+    (when (< 0 size)
+      (write-sequence data (stream drain) :start start :end (+ start size))
+      (incf (mixed:frame-position drain)
+            (/ size (mixed:framesize (mixed:pack drain))))
+      (mixed:finish size))))
+
+(defmethod mixed:end :after ((drain raw-file-drain))
+  (when (and (stream drain)
+             (not (dont-close-p drain)))
+    (close (stream drain))
+    (setf (stream drain) NIL)))
+
+(defmethod mixed:free :after ((drain raw-file-drain))
+  (when (and (stream drain)
+             (not (dont-close-p drain)))
+    (close (stream drain) :abort T)
+    (setf (stream drain) NIL)))
+
+(defun play-to-file (file &key output output-stream
+                               (samplerate 44100) (encoding :float)
+                               (input-format :mp3) (output-format :wav))
+  (mixed:with-objects ((source (mixed:make-unpacker :samplerate samplerate))
+                       (drain (mixed:make-packer :samplerate samplerate :encoding encoding))
+                       (in (make-instance (ecase input-format
+                                            (:mp3 'org.shirakumo.fraf.mixed.mpg123:source)
+                                            (:wav 'org.shirakumo.fraf.mixed.wav:in-memory-source))
+                                          :file (pathname file) :pack source))
+                       (out (make-instance (ecase output-format
+                                             (:wav 'org.shirakumo.fraf.mixed.wav:file-drain)
+                                             (:raw 'raw-file-drain))
+                                           :file (pathname output) :pack drain
+                                           :stream output-stream :dont-close output-stream)))
+    (mixed:with-buffers 500 (l r)
+      (mixed:connect source :left drain :left l)
+      (mixed:connect source :right drain :right r)
+      (mixed:with-chain chain (in source drain out)
+        (format T "~&Writing a file with ~d channels @ ~dHz, ~a~%"
+                (mixed:channels drain) (mixed:samplerate drain) (mixed:encoding drain))
+        (loop until (mixed:done-p in)
+              do (mixed:mix chain))
+        (format T "Wrote ~d frames." (mixed:frame-position out))))))

--- a/extensions/wav.lisp
+++ b/extensions/wav.lisp
@@ -244,10 +244,7 @@
 (defmethod mixed:start ((drain file-drain))
   (unless (riff-chunk-offset drain)     ; Check if we already started
     (with-slots (stream mixed:pack) drain
-      (let* ((samplesize (mixed:samplesize (mixed:encoding mixed:pack)))
-             (framesize (mixed:framesize mixed:pack))
-             (byterate (* (mixed:samplerate mixed:pack) framesize))
-             (audio-format (audio-format (mixed:encoding mixed:pack))))
+      (let ((audio-format (audio-format (mixed:encoding mixed:pack))))
         (write-label stream "RIFF")     ; RIFF chunk
         (setf (riff-chunk-offset drain) (file-position stream)) ; skip size field, save offset
         (write-int stream 4 0)
@@ -257,9 +254,10 @@
         (write-int stream 2 audio-format)
         (write-int stream 2 (mixed:channels mixed:pack))
         (write-int stream 4 (mixed:samplerate mixed:pack))
-        (write-int stream 4 byterate)
-        (write-int stream 2 framesize)
-        (write-int stream 2 (* 8 samplesize))
+        (write-int stream 4 (* (mixed:samplerate mixed:pack)
+                               (mixed:framesize mixed:pack)))
+        (write-int stream 2 (mixed:framesize mixed:pack))
+        (write-int stream 2 (* 8 (mixed:samplesize (mixed:encoding mixed:pack))))
         (when (= audio-format 3)
           (write-int stream 2 2)
           (write-label stream "fact")   ; fact chunk

--- a/extensions/wav.lisp
+++ b/extensions/wav.lisp
@@ -291,9 +291,8 @@
         (write-int stream 4 riff-size)
         ;; Set number of samples in fact chunk when needed
         (when (fact-chunk-offset drain)
-          (let ((samples (/ data-size (mixed:samplesize (mixed:encoding mixed:pack)))))
-            (file-position stream (fact-chunk-offset drain))
-            (write-int stream 4 samples)))
+          (file-position stream (fact-chunk-offset drain))
+          (write-int stream 4 (* (mixed:channels mixed:pack) (mixed:frame-position drain))))
         ;; Set data chunk size
         (file-position stream (data-chunk-offset drain))
         (write-int stream 4 data-size)

--- a/extensions/wav.lisp
+++ b/extensions/wav.lisp
@@ -245,8 +245,8 @@
   (unless (riff-chunk-offset drain)     ; Check if we already started
     (with-slots (stream mixed:pack) drain
       (let* ((samplesize (mixed:samplesize (mixed:encoding mixed:pack)))
-             (block-align (* (mixed:channels mixed:pack) samplesize))
-             (byterate (* (mixed:samplerate mixed:pack) block-align))
+             (framesize (mixed:framesize mixed:pack))
+             (byterate (* (mixed:samplerate mixed:pack) framesize))
              (audio-format (audio-format (mixed:encoding mixed:pack))))
         (write-label stream "RIFF")     ; RIFF chunk
         (setf (riff-chunk-offset drain) (file-position stream)) ; skip size field, save offset
@@ -258,7 +258,7 @@
         (write-int stream 2 (mixed:channels mixed:pack))
         (write-int stream 4 (mixed:samplerate mixed:pack))
         (write-int stream 4 byterate)
-        (write-int stream 2 block-align)
+        (write-int stream 2 framesize)
         (write-int stream 2 (* 8 samplesize))
         (when (= audio-format 3)
           (write-int stream 2 2)

--- a/extensions/wav.lisp
+++ b/extensions/wav.lisp
@@ -272,6 +272,8 @@
   (mixed:with-buffer-tx (data start size (mixed:pack drain))
     (when (< 0 size)
       (write-sequence data (stream drain) :start start :end (+ start size))
+      (incf (mixed:frame-position drain)
+            (/ size (mixed:framesize (mixed:pack drain))))
       (mixed:finish size))))
 
 (defmethod mixed:end ((drain file-drain))

--- a/package.lisp
+++ b/package.lisp
@@ -203,7 +203,8 @@
    #:device
    #:file-drain
    #:file
-   #:stream)
+   #:stream
+   #:dont-close-p)
   ;; mixer.lisp
   (:export
    #:mixer

--- a/package.lisp
+++ b/package.lisp
@@ -160,7 +160,7 @@
 (defpackage #:org.shirakumo.fraf.mixed
   (:use #:cl #:cffi)
   (:import-from #:org.shirakumo.fraf.mixed.cffi #:size_t)
-  (:shadow #:space #:byte-position)
+  (:shadow #:space #:byte-position #:stream)
   (:local-nicknames
    (#:mixed #:org.shirakumo.fraf.mixed.cffi))
   ;; bip-buffer.lisp
@@ -200,7 +200,10 @@
    #:device-not-found
    #:device-drain
    #:list-devices
-   #:device)
+   #:device
+   #:file-drain
+   #:file
+   #:stream)
   ;; mixer.lisp
   (:export
    #:mixer

--- a/package.lisp
+++ b/package.lisp
@@ -160,7 +160,7 @@
 (defpackage #:org.shirakumo.fraf.mixed
   (:use #:cl #:cffi)
   (:import-from #:org.shirakumo.fraf.mixed.cffi #:size_t)
-  (:shadow #:space #:byte-position #:stream)
+  (:shadow #:space #:byte-position)
   (:local-nicknames
    (#:mixed #:org.shirakumo.fraf.mixed.cffi))
   ;; bip-buffer.lisp
@@ -202,9 +202,7 @@
    #:list-devices
    #:device
    #:file-drain
-   #:file
-   #:stream
-   #:dont-close-p)
+   #:file)
   ;; mixer.lisp
   (:export
    #:mixer


### PR DESCRIPTION
Adds `file-drain` class which opens and closes a stream for `mixed:start`, `mixed:end` and `mixed:free`.
You can pass `:file` or `:stream` argument to choose destination.
You can pass `:dont-close T` to prevent closing the passed stream.

Adds `mixed.wav:file-drain` which implements WAV format.

Important note: it shadows `#:stream` in `#:org.shirakumo.fraf.mixed` package - I used it as field name of `file-drain` class.

Also I didn't add documentation yet.