### PR TITLE
Fix pulse mic

### DIFF
--- a/examples/cl-mixed-examples.asd
+++ b/examples/cl-mixed-examples.asd
@@ -20,8 +20,10 @@
                (:file "echo")
                (:file "play")
                (:file "play-to-file")
-               (:file "mixer"))
+               (:file "mixer")
+               (:file "record-to-file"))
   :depends-on (:cl-mixed
                :cl-mixed-out123
                :cl-mixed-mpg123
-               :cl-mixed-wav))
+               :cl-mixed-wav
+               :cl-mixed-pulse))

--- a/examples/package.lisp
+++ b/examples/package.lisp
@@ -17,6 +17,7 @@
    #:play-to-file
    #:echo
    #:space
-   #:tone))
+   #:tone
+   #:record-to-file))
 
 (in-package #:org.shirakumo.fraf.mixed.examples)

--- a/examples/record-to-file.lisp
+++ b/examples/record-to-file.lisp
@@ -1,0 +1,22 @@
+#|
+ This file is a part of cl-mixed
+ (c) 2017 Shirakumo http://tymoon.eu (shinmera@tymoon.eu)
+ Author: Gleefre
+|#
+
+(in-package #:org.shirakumo.fraf.mixed.examples)
+
+(defun record-to-file (file seconds &key (samplerate 44100) (encoding :float))
+  (mixed:with-objects ((input (mixed:make-unpacker :samplerate samplerate))
+                       (output (mixed:make-packer :samplerate samplerate :encoding encoding))
+                       (file-drain (make-instance 'org.shirakumo.fraf.mixed.wav:file-drain
+                                                  :pack output :file file))
+                       (mic (make-instance 'org.shirakumo.fraf.mixed.pulse:source
+                                           :pack input)))
+    (mixed:with-buffers 500 (l r)
+      (mixed:connect input :left output :left l)
+      (mixed:connect input :right output :right r)
+      (mixed:with-chain chain (mic input output file-drain)
+        (loop while (< (mixed:frame-position file-drain)
+                       (* seconds samplerate))
+              do (mixed:mix chain))))))

--- a/extensions/pulse.lisp
+++ b/extensions/pulse.lisp
@@ -116,7 +116,8 @@
     (pulse:simple-drain (simple drain) err)))
 
 (defclass source (mixed:source)
-  ((simple :initform NIL :accessor simple)
+  ((mixed:program-name :initform "Mixed" :initarg :program-name :accessor mixed:program-name)
+   (simple :initform NIL :accessor simple)
    (server :initform NIL :initarg :server :accessor server)
    (channel-order :initform () :initarg :channel-order :accessor mixed:channel-order)))
 


### PR DESCRIPTION
Fixes `pulse:source` class - the PROGRAM-NAME slot was forgotten.

Also adds a `record-to-file` example, though I can discard it.