### PR TITLE
Coerce arguments to float during segments initialization.

### DIFF
--- a/segments/delay.lisp
+++ b/segments/delay.lisp
@@ -13,7 +13,7 @@
 
 (defmethod initialize-instance :after ((segment delay) &key time samplerate bypass)
   (with-error-on-failure ()
-    (mixed:make-segment-delay time samplerate (handle segment)))
+    (mixed:make-segment-delay (float time 0f0) samplerate (handle segment)))
   (setf (bypass segment) bypass))
 
 (defun make-delay (&rest args &key time samplerate)

--- a/segments/fader.lisp
+++ b/segments/fader.lisp
@@ -17,7 +17,7 @@
 
 (defmethod initialize-instance :after ((segment fader) &key from to time type samplerate bypass)
   (with-error-on-failure ()
-    (mixed:make-segment-fade from to time type samplerate (handle segment)))
+    (mixed:make-segment-fade (float from 0f0) (float to 0f0) (float time 0f0) type samplerate (handle segment)))
   (setf (bypass segment) bypass))
 
 (defun make-fader (&rest args &key from to time type samplerate)

--- a/segments/pitch.lisp
+++ b/segments/pitch.lisp
@@ -14,7 +14,7 @@
 
 (defmethod initialize-instance :after ((segment pitch) &key pitch samplerate bypass wet)
   (with-error-on-failure ()
-    (mixed:make-segment-pitch pitch samplerate (handle segment)))
+    (mixed:make-segment-pitch (float pitch 0f0) samplerate (handle segment)))
   (when wet (setf (wet segment) wet))
   (setf (bypass segment) bypass))
 

--- a/segments/repeat.lisp
+++ b/segments/repeat.lisp
@@ -13,7 +13,7 @@
 
 (defmethod initialize-instance :after ((segment repeat) &key time samplerate bypass)
   (with-error-on-failure ()
-    (mixed:make-segment-repeat time samplerate (handle segment)))
+    (mixed:make-segment-repeat (float time 0f0) samplerate (handle segment)))
   (setf (bypass segment) bypass))
 
 (defun make-repeat (&rest args &key time samplerate)

--- a/segments/volume-control.lisp
+++ b/segments/volume-control.lisp
@@ -14,7 +14,7 @@
 
 (defmethod initialize-instance :after ((segment volume-control) &key volume pan bypass)
   (with-error-on-failure ()
-    (mixed:make-segment-volume-control volume pan (handle segment)))
+    (mixed:make-segment-volume-control (float volume 0f0) (float pan 0f0) (handle segment)))
   (setf (bypass segment) bypass))
 
 (defun make-volume-control (&rest args &key volume pan)


### PR DESCRIPTION
Allows to do `(mixed:make-pitch :pitch 2)` and others.