### PR TITLE
Fix typo

### DIFF
--- a/segments/virtual.lisp
+++ b/segments/virtual.lisp
@@ -52,7 +52,7 @@
   (setf (aref (inputs segment) location) value))
 
 (defmethod (setf output-field) ((value null) (field (eql :buffer)) (location integer) (segment virtual))
-  (setf (aref (inputs segment) location) value))
+  (setf (aref (outputs segment) location) value))
 
 (define-callback virtual-free :void ((segment :pointer))
     NIL


### PR DESCRIPTION
As discussed on #shirakumo `(setf output-field)` on a virtual segment uses `inputs` instead of `outputs`