### PR TITLE
Fix OSS backend.

### DIFF
--- a/extensions/oss.lisp
+++ b/extensions/oss.lisp
@@ -49,7 +49,8 @@
 
 (defmethod mixed:end ((oss-device oss-device)))
 
-(defclass source (mixed:source oss-device) ())
+;; In this class and in DRAIN put OSS-DEVICE first as its INITIALIZE-INSTANCE :AFTER method should be run last.
+(defclass source (oss-device mixed:source) ())
 
 (defmethod fd-flag ((source source)) :read-only)
 
@@ -60,7 +61,7 @@
         (error "Failed to read."))
       (mixed:finish result))))
 
-(defclass drain (mixed:drain oss-device) ())
+(defclass drain (oss-device mixed:drain) ())
 
 (defmethod fd-flag ((drain drain)) :write-only)
 


### PR DESCRIPTION
Just reorder superclasses of `...oss:drain` so that `pack` slot can be initialized properly before entering `initialize-instance` for `oss-device`.

Check this if not sure:

```lisp
(defclass foo () ())
(defclass bar () ())
(defclass foobar (foo bar) ())
(defmethod initialize-instance :after ((foo foo) &key)
  (print 'foo))
(defmethod initialize-instance :after ((bar bar) &key)
  (print 'bar))
(make-instance 'foobar)
```